### PR TITLE
Fixes to how AWS Responses are handled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neap/funky",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Lightweight Serverless HTTP handler. It supports CORS and also assists in initialization of web app projects hosted on Google Cloud Functions, AWS Lambda or any standard NodeJs Express server.",
   "contributors": [
     "Nicolas Dao <nic@neap.co> (https://neap.co/)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neap/funky",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Lightweight Serverless HTTP handler. It supports CORS and also assists in initialization of web app projects hosted on Google Cloud Functions, AWS Lambda or any standard NodeJs Express server.",
   "contributors": [
     "Nicolas Dao <nic@neap.co> (https://neap.co/)"

--- a/src/utils/legacy.js
+++ b/src/utils/legacy.js
@@ -198,21 +198,35 @@ const createAWSRequestResponse = (event={}, paramsPropName) => {
 
 const createAWSResponse = (res={}) => {
 	try {
-		const response = res._getData()
-		const isResponseString = typeof(response) == 'string';
+		const body = res._getData()
+		const isString = typeof(body) == 'string';
 		const redirectUrl = res._getRedirectUrl()
 		const headers = res._getHeaders ? res._getHeaders() : {}
 
-		if (isResponseString)
+		if (isString)
 			headers['Content-Type'] = 'text/html'
 
 		if (redirectUrl)
 			headers.Location = redirectUrl;
 
+		Object.keys(res.cookies || {}).forEach(cookieName => {	
+			const cookie = res.cookies[cookieName]
+			const options = cookie.options || {}
+			const arr = []
+
+			arr.push(`${cookieName}=${cookie.value}`)
+
+			Object.keys(options).forEach(optionName => {
+				arr.push(`${optionName}=${options[optionName]}`)
+			})
+
+			headers["Set-Cookie"] = arr.join("; ")
+		})
+
 		return {
 			statusCode: res.statusCode || 400,
 			headers,
-			body: response ? isResponseString ? response : JSON.stringify(response) : ''
+			body: body ? isString ? body : JSON.stringify(body) : ''
 		}
 	}
 	catch(err) {

--- a/src/utils/legacy.js
+++ b/src/utils/legacy.js
@@ -199,9 +199,15 @@ const createAWSRequestResponse = (event={}, paramsPropName) => {
 const createAWSResponse = (res={}) => {
 	try {
 		const response = res._getData()
+		const redirectUrl = res._getRedirectUrl()
+		const headers = res._getHeaders ? res._getHeaders() : {}
+
+		if (redirectUrl)
+			headers.location = redirectUrl;
+
 		return {
 			statusCode: res.statusCode || 400,
-			headers: res._getHeaders ? res._getHeaders() : {},
+			headers,
 			body: response ? typeof(response) == 'string' ? response : JSON.stringify(response) : ''
 		}
 	}

--- a/src/utils/legacy.js
+++ b/src/utils/legacy.js
@@ -199,16 +199,20 @@ const createAWSRequestResponse = (event={}, paramsPropName) => {
 const createAWSResponse = (res={}) => {
 	try {
 		const response = res._getData()
+		const isResponseString = typeof(response) == 'string';
 		const redirectUrl = res._getRedirectUrl()
 		const headers = res._getHeaders ? res._getHeaders() : {}
 
+		if (isResponseString)
+			headers['Content-Type'] = 'text/html'
+
 		if (redirectUrl)
-			headers.location = redirectUrl;
+			headers.Location = redirectUrl;
 
 		return {
 			statusCode: res.statusCode || 400,
 			headers,
-			body: response ? typeof(response) == 'string' ? response : JSON.stringify(response) : ''
+			body: response ? isResponseString ? response : JSON.stringify(response) : ''
 		}
 	}
 	catch(err) {


### PR DESCRIPTION
This PR contains the following fixes to AWS Responses (Lambdas + API Gateway):

- text/html content-type is set when the body is a string
- Location header is set when there is a redirect url
- Set-Cookie header is set when there are cookies (currently only handling one cookie, but I'll try update this code to handle multiple cookies - short on time right now)